### PR TITLE
Remove safe-eval and run through eval

### DIFF
--- a/src/swagger-utils.js
+++ b/src/swagger-utils.js
@@ -1,5 +1,4 @@
 const matchAll = require('match-all');
-const safeEval = require('safe-eval');
 const { writeFileSync } = require('fs');
 
 const { debugLogger } = require('./logger');
@@ -422,8 +421,10 @@ const getParameterDependencies = (route, method, parameters, name, strictMode = 
 
 const evaluateRoute = (route, context) => {
   const routeDeps = matchAll(route, routeDependencyRegex).toArray();
+  logger(`Evaluating route with context: ${JSON.stringify(context, null, 4)}`);
   for (const dependency of routeDeps) {
-    const value = safeEval(dependency.slice(1), context);
+    // eslint-disable-next-line no-eval
+    const value = eval(`context.${dependency.slice(1)}`);
     route = route.replace(dependency, value);
   }
 

--- a/test/swagger-utils.spec.ts
+++ b/test/swagger-utils.spec.ts
@@ -4,6 +4,7 @@ import {
   getType,
   swaggerRef,
   buildSwaggerJSON,
+  evaluateRoute,
   generateResponse,
   findBodyParameterIndexV2,
   findPathParameterIndex,
@@ -216,5 +217,11 @@ describe('Swagger utils tests', () => {
     const data = parseSwaggerRouteData(swaggerSpec as any, swaggerSamples);
 
     expect(data).deep.equal(getSpec());
+  });
+
+  it('evaluateRoute works as expected', () => {
+    const route = '/api/v1/$Organization.id';
+    const context = { Organization: { id: 1 } };
+    expect(evaluateRoute(route, context)).to.equal('/api/v1/1');
   });
 });


### PR DESCRIPTION
Defer the use of safe-eval due to security issues, evaluate the use of eval with the default context

NOTE: This is temporary and I'd create an issue to remove the use of eval completely.