### PR TITLE
Use existing data to when documenting new request. 

### DIFF
--- a/src/swagger-utils.js
+++ b/src/swagger-utils.js
@@ -331,7 +331,7 @@ const generateResponseBodySpec = (
   contentType,
   statusCode,
 ) => {
-  if (!Object.keys(responseBody).length) {
+  if (!responseBody || !Object.keys(responseBody).length) {
     return;
   }
   const definitionName = generateResponseRef();
@@ -613,4 +613,5 @@ module.exports = {
   replaceRoutes,
   trimString,
   NonPrimitiveTypes,
+  generateResponseBodySpec,
 };

--- a/test/swagger-utils.spec.ts
+++ b/test/swagger-utils.spec.ts
@@ -13,6 +13,7 @@ import {
   replaceRoutes,
   parseSwaggerRouteData,
   generateResponseRef,
+  generateResponseBodySpec
 } from '../src';
 import options from '../examples/swagger-config';
 import { getSpec } from './fixtures';
@@ -296,5 +297,9 @@ describe('Swagger utils tests', () => {
     const route = '/api/v1/$Organization.id';
     const context = { Organization: { id: 1 } };
     expect(evaluateRoute(route, context)).to.equal('/api/v1/1');
+  });
+
+  it('generateResponseBodySpec should return undefined on empty input', () => {
+    expect(generateResponseBodySpec()).to.equal(undefined);
   });
 });


### PR DESCRIPTION
* Will now check existing requestbody data to determine if field is req…
* Will now merge examples instead of creating new ones, allowing for better optional field examples